### PR TITLE
revert pop indices in iiwa_api delete configs

### DIFF
--- a/iiwa_apis.py
+++ b/iiwa_apis.py
@@ -111,6 +111,7 @@ def iiwa_remove_device(deviceID):
 			if (iiwa_sensors_configurations[x]['device_id'] == remove_device_id):
 				pop_indices.append(x)
 
+		pop_indices=pop_indices[::-1]
 		for b in range(0, len(pop_indices)):
 			iiwa_sensors_configurations.pop(pop_indices[b])
 


### PR DESCRIPTION
I believe this solves the issue of deleting from iiwa a device with two sensors.